### PR TITLE
fix(db): move schema definitions to array syntax and update test env config

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bun --hot --env-file=../../.env src/index.ts",
     "start": "bun src/index.ts",
-    "test": "bun --env-file=../../.env tests/main.ts",
+    "test": "bun --env-file=../../.env.test tests/main.ts",
     "build": "bun build src/index.ts --outdir ./dist --target bun",
     "format": "prettier --config ../../.prettierrc --ignore-path ../../.prettierignore --write ."
   },

--- a/packages/database/src/schema/auth.ts
+++ b/packages/database/src/schema/auth.ts
@@ -69,10 +69,7 @@ export const session = pgTable(
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' }),
   },
-  (table) => ({
-    userIdx: index('session_user_id_idx').on(table.userId),
-    expiresAtIdx: index('session_expires_at_idx').on(table.expiresAt),
-  }),
+  (table) => [index('session_user_id_idx').on(table.userId), index('session_expires_at_idx').on(table.expiresAt)],
 );
 
 export const verification = pgTable('verification', {

--- a/packages/database/src/schema/citizens.ts
+++ b/packages/database/src/schema/citizens.ts
@@ -28,7 +28,5 @@ export const userEducationProgress = pgTable(
     score: integer('score'),
     timeSpentSeconds: integer('time_spent_seconds'),
   },
-  (table) => ({
-    pk: primaryKey({ columns: [table.userId, table.contentId] }),
-  }),
+  (table) => [primaryKey({ columns: [table.userId, table.contentId] })],
 );

--- a/packages/database/src/schema/communications.ts
+++ b/packages/database/src/schema/communications.ts
@@ -17,9 +17,7 @@ export const dispatchMessage = pgTable(
     readAt: timestamp('read_at'),
     sentAt: timestamp('sent_at').defaultNow().notNull(),
   },
-  (table) => ({
-    recipientSentIdx: index('dispatch_message_recipient_sent_idx').on(table.recipientId, table.sentAt),
-  }),
+  (table) => [index('dispatch_message_recipient_sent_idx').on(table.recipientId, table.sentAt)],
 );
 
 export const pushNotificationToken = pgTable(
@@ -33,7 +31,5 @@ export const pushNotificationToken = pgTable(
     lastUsedAt: timestamp('last_used_at').defaultNow().notNull(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
   },
-  (table) => ({
-    userIdx: index('push_notification_token_user_idx').on(table.userId),
-  }),
+  (table) => [index('push_notification_token_user_idx').on(table.userId)],
 );

--- a/packages/database/src/schema/issues.ts
+++ b/packages/database/src/schema/issues.ts
@@ -26,10 +26,10 @@ export const systemAlert = pgTable(
     driverId: text('driver_id').references(() => user.id, { onDelete: 'set null' }),
     createdAt: timestamp('created_at').defaultNow().notNull(),
   },
-  (table) => ({
-    statusIdx: index('system_alert_status_idx').on(table.status),
-    createdAtIdx: index('system_alert_created_at_idx').on(table.createdAt),
-  }),
+  (table) => [
+    index('system_alert_status_idx').on(table.status),
+    index('system_alert_created_at_idx').on(table.createdAt),
+  ],
 );
 
 export const driverIssueReport = pgTable(
@@ -50,10 +50,10 @@ export const driverIssueReport = pgTable(
     createdAt: timestamp('created_at').defaultNow().notNull(),
     resolvedAt: timestamp('resolved_at'),
   },
-  (table) => ({
-    statusIdx: index('driver_issue_report_status_idx').on(table.status),
-    driverIdx: index('driver_issue_report_driver_idx').on(table.driverId),
-  }),
+  (table) => [
+    index('driver_issue_report_status_idx').on(table.status),
+    index('driver_issue_report_driver_idx').on(table.driverId),
+  ],
 );
 
 export const citizenIssueReport = pgTable(
@@ -75,8 +75,8 @@ export const citizenIssueReport = pgTable(
       .notNull()
       .$onUpdate(() => new Date()),
   },
-  (table) => ({
-    statusIdx: index('citizen_issue_report_status_idx').on(table.status),
-    typeIdx: index('citizen_issue_report_type_idx').on(table.type),
-  }),
+  (table) => [
+    index('citizen_issue_report_status_idx').on(table.status),
+    index('citizen_issue_report_type_idx').on(table.type),
+  ],
 );

--- a/packages/database/src/schema/routes.ts
+++ b/packages/database/src/schema/routes.ts
@@ -37,9 +37,7 @@ export const route = pgTable(
       .notNull()
       .$onUpdate(() => new Date()),
   },
-  (table) => ({
-    statusIdx: index('route_status_idx').on(table.status),
-  }),
+  (table) => [index('route_status_idx').on(table.status)],
 );
 
 export const routeWaypoint = pgTable(
@@ -55,9 +53,7 @@ export const routeWaypoint = pgTable(
     streetName: text('street_name'),
     estimatedArrivalOffsetMinutes: integer('estimated_arrival_offset_minutes').notNull(),
   },
-  (table) => ({
-    routeSequenceIdx: index('route_waypoint_route_sequence_idx').on(table.routeId, table.sequenceOrder),
-  }),
+  (table) => [index('route_waypoint_route_sequence_idx').on(table.routeId, table.sequenceOrder)],
 );
 
 export const routeSchedule = pgTable(
@@ -69,10 +65,10 @@ export const routeSchedule = pgTable(
     dayOfWeek: integer('day_of_week').notNull(),
     startTime: time('start_time').notNull(),
   },
-  (table) => ({
-    pk: uniqueIndex('route_schedule_pkey').on(table.routeId, table.dayOfWeek),
-    dayIdx: index('route_schedule_day_idx').on(table.dayOfWeek),
-  }),
+  (table) => [
+    uniqueIndex('route_schedule_pkey').on(table.routeId, table.dayOfWeek),
+    index('route_schedule_day_idx').on(table.dayOfWeek),
+  ],
 );
 
 export const routeAssignment = pgTable(
@@ -101,9 +97,9 @@ export const routeAssignment = pgTable(
       .references(() => user.id),
     createdAt: timestamp('created_at').defaultNow().notNull(),
   },
-  (table) => ({
-    driverDateIdx: index('idx_assignment_driver_date').on(table.driverId, table.assignedDate),
-    truckDateIdx: index('idx_assignment_truck_date').on(table.truckId, table.assignedDate),
-    dateStatusIdx: index('idx_assignment_date_status').on(table.assignedDate, table.status),
-  }),
+  (table) => [
+    index('idx_assignment_driver_date').on(table.driverId, table.assignedDate),
+    index('idx_assignment_truck_date').on(table.truckId, table.assignedDate),
+    index('idx_assignment_date_status').on(table.assignedDate, table.status),
+  ],
 );

--- a/packages/database/src/schema/trucks.ts
+++ b/packages/database/src/schema/trucks.ts
@@ -38,8 +38,8 @@ export const truckLocationHistory = pgTable(
     heading: doublePrecision('heading'),
     recordedAt: timestamp('recorded_at').defaultNow().notNull(),
   },
-  (table) => ({
-    truckRecordedIdx: index('truck_location_history_truck_recorded_idx').on(table.truckId, table.recordedAt),
-    assignmentIdx: index('truck_location_history_assignment_idx').on(table.routeAssignmentId),
-  }),
+  (table) => [
+    index('truck_location_history_truck_recorded_idx').on(table.truckId, table.recordedAt),
+    index('truck_location_history_assignment_idx').on(table.routeAssignmentId),
+  ],
 );


### PR DESCRIPTION
This patch refactors how indexes and constraints are declared across multiple schema files. The object-based syntax in pgTable definitions has been replaced with array syntax for improved consistency and compatibility with the schema library.

Refactored schema files:

* packages/database/src/schema/auth.ts
* packages/database/src/schema/citizens.ts
* packages/database/src/schema/communications.ts
* packages/database/src/schema/issues.ts
* packages/database/src/schema/routes.ts
* packages/database/src/schema/trucks.ts

Additional change:

* Updated apps/api/package.json test script to load .env.test instead of .env, ensuring tests run with the correct environment configuration.