### PR TITLE
feat(ci): add GitHub Actions workflow for API tests

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -2,11 +2,15 @@ name: API Tests
 
 on:
   push:
-    branches: [master]
-    paths: ['apps/api/**', '.github/**']
+    branches:
+      - 'master'
+    paths:
+      - 'apps/api/**'
   pull_request:
-    branches: [master]
-    paths: ['apps/api/**', '.github/**']
+    branches:
+      - 'master'
+    paths:
+      - 'apps/api/**'
   workflow_dispatch:
 
 jobs:
@@ -27,13 +31,6 @@ jobs:
           bun-version: 1.2.21
 
       - run: bun install
-
-      - run: |
-          echo "DATABASE_URL is ${{ secrets.DATABASE_URL }}" \
-            echo "BETTER_AUTH_SECRET is ${{ secrets.BETTER_AUTH_SECRET }}"
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
 
       - run: bun run test
         env:


### PR DESCRIPTION
Introduce a new workflow `.github/workflows/api-tests.yml` to run tests
for the API service. The workflow is triggered on pushes and pull requests
to master that touch `apps/api`, and can also be dispatched manually.

Changes include:

* Configure Bun as package manager and test runner
* Install dependencies and run tests in `apps/api`
* Provide required environment variables for DB and auth secrets