### PR TITLE
chore(api): apply style consistency and minor fixes across API and tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@hono-rate-limiter/cloudflare": "^0.2.2",
     "@hono/zod-validator": "^0.7.2",
-    "better-auth": "^1.3.7",
+    "better-auth": "^1.3.10",
     "hono": "^4.9.6",
     "pg": "^8.16.3"
   },

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,7 +1,7 @@
 import process from 'node:process';
 import app from '@/app.ts';
 
-const port = parseInt(process.env.PORT || '4000', 10);
+const port = Number.parseInt(process.env.PORT || '4000', 10);
 
 console.log(`@lima-garbage/api is live at http://localhost:${port}`);
 console.log(`health: http://localhost:${port}/api/health`);

--- a/apps/api/src/lib/db.ts
+++ b/apps/api/src/lib/db.ts
@@ -9,7 +9,7 @@ export const db = new Pool({
   connectionString: process.env.DATABASE_URL,
   ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
   max: 20,
-  idleTimeoutMillis: 30000,
+  idleTimeoutMillis: 30_000,
   connectionTimeoutMillis: 2000,
 });
 

--- a/apps/api/src/lib/validation.ts
+++ b/apps/api/src/lib/validation.ts
@@ -6,7 +6,9 @@ export type Role = z.infer<typeof roleSchema>;
 export const IdSchema = z.union([
   z.uuid(),
   // IDs created by better-auth don't use standard UUID format
-  z.string().regex(/^[a-zA-Z0-9]{20,40}$/),
+  z
+    .string()
+    .regex(/^[a-zA-Z0-9]{20,40}$/),
 ]);
 export const IdParamSchema = z.object({ id: IdSchema });
 

--- a/apps/api/src/routes/citizen.ts
+++ b/apps/api/src/routes/citizen.ts
@@ -83,13 +83,12 @@ citizenRouter.get('/truck/status', async (c) => {
           etaMinutes: Math.max(1, etaMinutes),
           truck: truck.truck_name,
         });
-      } else {
-        return c.json({
-          status: 'ON_THE_WAY',
-          etaMinutes,
-          truck: truck.truck_name,
-        });
       }
+      return c.json({
+        status: 'ON_THE_WAY',
+        etaMinutes,
+        truck: truck.truck_name,
+      });
     }
 
     return c.json({

--- a/apps/api/src/routes/driver.ts
+++ b/apps/api/src/routes/driver.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono';
 import type { Session, User } from '@/lib/auth.ts';
 import { db, withTransaction } from '@/lib/db.ts';
 import { authMiddleware } from '@/lib/middleware.ts';
-import { createDriverIssueSchema, updateDriverLocationSchema, IdParamSchema } from '@/lib/validation.ts';
+import { createDriverIssueSchema, IdParamSchema, updateDriverLocationSchema } from '@/lib/validation.ts';
 
 type AuthEnv = {
   Variables: {

--- a/apps/api/test-runner.ts
+++ b/apps/api/test-runner.ts
@@ -1,3 +1,5 @@
+import process from 'node:process';
+
 const server = Bun.spawn(['bun', '--env-file=../../.env.test', 'src/index.ts'], {
   stdout: 'inherit',
   stderr: 'inherit',

--- a/apps/api/tests/config.ts
+++ b/apps/api/tests/config.ts
@@ -1,3 +1,5 @@
+import process from 'node:process';
+
 export const TEST_CONFIG = {
   baseUrl: process.env.API_BASE_URL || 'http://localhost:4000/api',
 } as const;

--- a/apps/api/tests/helpers/auth-helper.ts
+++ b/apps/api/tests/helpers/auth-helper.ts
@@ -12,9 +12,9 @@ interface Session {
 }
 
 export class AuthHelper {
-  private client: TestClient;
-  private sessions = new Map<string, Session>();
-  private testUsers: TestUsers;
+  private readonly client: TestClient;
+  private readonly sessions = new Map<string, Session>();
+  private readonly testUsers: TestUsers;
 
   constructor(client: TestClient, testUsers: TestUsers) {
     this.client = client;

--- a/apps/api/tests/helpers/db-helper.ts
+++ b/apps/api/tests/helpers/db-helper.ts
@@ -1,7 +1,9 @@
+import process from 'node:process';
+
 import { Pool } from 'pg';
 
 export class DbHelper {
-  private pool: Pool;
+  private readonly pool: Pool;
 
   constructor() {
     if (!process.env.DATABASE_URL) {

--- a/apps/api/tests/helpers/test-client.ts
+++ b/apps/api/tests/helpers/test-client.ts
@@ -7,7 +7,7 @@ interface Response<T = any> {
 }
 
 export class TestClient {
-  private baseUrl: string;
+  private readonly baseUrl: string;
 
   constructor() {
     this.baseUrl = TEST_CONFIG.baseUrl;

--- a/apps/api/tests/helpers/test-users.ts
+++ b/apps/api/tests/helpers/test-users.ts
@@ -1,3 +1,5 @@
+import process from 'node:process';
+
 import type { DbHelper } from './db-helper.ts';
 import type { TestClient } from './test-client.ts';
 
@@ -9,9 +11,9 @@ interface UserConfig {
 }
 
 export class TestUsers {
-  private client: TestClient;
-  private db: DbHelper;
-  private users: Record<'admin' | 'driver' | 'citizen', UserConfig> = {
+  private readonly client: TestClient;
+  private readonly db: DbHelper;
+  private readonly users: Record<'admin' | 'driver' | 'citizen', UserConfig> = {
     admin: {
       email: process.env.TEST_ADMIN_EMAIL || 'admin@test.com',
       password: 'admin123456',

--- a/apps/api/tests/integration.test.ts
+++ b/apps/api/tests/integration.test.ts
@@ -73,7 +73,7 @@ test('complete workflow: admin creates resources, driver gets assignment', async
     truck_name: truck.name,
     status: 'scheduled',
   });
-}, 15000);
+}, 15_000);
 
 test('citizen can report issue and admin can view it', async () => {
   await ctx.auth.loginAs('citizen');
@@ -100,7 +100,7 @@ test('citizen can report issue and admin can view it', async () => {
 
   expect(adminIssuesResponse.status).toBe(200);
   expect(Array.isArray(adminIssuesResponse.data)).toBe(true);
-}, 15000);
+}, 15_000);
 
 test('role-based access control works across endpoints', async () => {
   await ctx.auth.loginAs('citizen');
@@ -126,7 +126,7 @@ test('role-based access control works across endpoints', async () => {
   // admin can access admin endpoints
   const adminToAdmin = await ctx.client.get('/admin/trucks', adminHeaders);
   expect(adminToAdmin.status).toBe(200);
-}, 15000);
+}, 15_000);
 
 afterAll(async () => {
   await ctx.db.close();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
-    "better-auth": "^1.3.7",
+    "better-auth": "^1.3.10",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.44.4",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
       "dependencies": {
         "@hono-rate-limiter/cloudflare": "^0.2.2",
         "@hono/zod-validator": "^0.7.2",
-        "better-auth": "^1.3.7",
+        "better-auth": "^1.3.10",
         "hono": "^4.9.6",
         "pg": "^8.16.3",
       },
@@ -62,7 +62,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.13",
-        "better-auth": "^1.3.7",
+        "better-auth": "^1.3.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.44.4",
@@ -307,7 +307,7 @@
 
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
-    "@better-auth/utils": ["@better-auth/utils@0.2.6", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-3y/vaL5Ox33dBwgJ6ub3OPkVqr6B5xL2kgxNHG8eHZuryLyG/4JSPGqjbdRSgjuy9kALUZYDFl+ORIAxlWMSuA=="],
+    "@better-auth/utils": ["@better-auth/utils@0.3.0", "", {}, "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw=="],
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.18", "", {}, "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA=="],
 
@@ -983,9 +983,9 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.8.4", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw=="],
 
-    "better-auth": ["better-auth@1.3.9", "", { "dependencies": { "@better-auth/utils": "0.2.6", "@better-fetch/fetch": "^1.1.18", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "@simplewebauthn/browser": "^13.1.2", "@simplewebauthn/server": "^13.1.2", "better-call": "1.0.18", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^0.11.4", "zod": "^4.1.5" }, "peerDependencies": { "@lynx-js/react": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@lynx-js/react", "react", "react-dom"] }, "sha512-Ty6BHzuShlqSs7I4RMlBRQ3duOWNB7WWriIu2FJVGjQAOtTVvamzFCR4/j5ROFLoNkpvNTRF7BJozsrMICL1gw=="],
+    "better-auth": ["better-auth@1.3.10", "", { "dependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "^1.1.18", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "@simplewebauthn/browser": "^13.1.2", "@simplewebauthn/server": "^13.1.2", "better-call": "1.0.19", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.1.5" }, "peerDependencies": { "@lynx-js/react": "*", "@sveltejs/kit": "^2.0.0", "next": "^14.0.0 || ^15.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@sveltejs/kit", "next", "react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-cEdvbqJ2TlTXUSktHKs8V3rHdFYkEG7QmQZpLXGjXZX6F0nYbTk2QPsWXNhxbinFAlE2ca4virzuDsmsQlLIVw=="],
 
-    "better-call": ["better-call@1.0.18", "", { "dependencies": { "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1", "uncrypto": "^0.1.3" } }, "sha512-Ojyck3P3fs/egBmCW50tvfbCJorNV5KphfPOKrkCxPfOr8Brth1ruDtAJuhHVHEUiWrXv+vpEgWQk7m7FzhbbQ=="],
+    "better-call": ["better-call@1.0.19", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1", "uncrypto": "^0.1.3" } }, "sha512-sI3GcA1SCVa3H+CDHl8W8qzhlrckwXOTKhqq3OOPXjgn5aTOMIqGY34zLY/pHA6tRRMjTUC3lz5Mi7EbDA24Kw=="],
 
     "better-opn": ["better-opn@3.0.2", "", { "dependencies": { "open": "^8.0.4" } }, "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ=="],
 
@@ -1643,7 +1643,7 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "nanostores": ["nanostores@0.11.4", "", {}, "sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ=="],
+    "nanostores": ["nanostores@1.0.1", "", {}, "sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.3", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow=="],
 


### PR DESCRIPTION
This patch introduces style and readability improvements in the API and test
codebase. The goal is to improve consistency, immutability, and clarity.

Changes include:

* Readability
  * Updated timeout values to use numeric separators in db.ts and integration tests
  * Replaced private class members with readonly declarations in test helpers

* Imports and organization
  * Added explicit imports of process from node\:process
  * Reordered imports in routes/driver.ts for consistency

* Minor fixes
  * Adjusted schema formatting in validation.ts
  * Corrected response handling logic in routes/citizen.ts
  * Replaced parseInt with Number.parseInt in index.ts