### PR TITLE
fix(web): enable Edge Runtime and refactor middleware cookie handling

### DIFF
--- a/apps/web/src/app/(routes)/(home)/page.tsx
+++ b/apps/web/src/app/(routes)/(home)/page.tsx
@@ -5,6 +5,8 @@ import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 //import { Dashboard }  from "@/components/dashboard"
 
+export const runtime = 'edge';
+
 export default async function Home() {
   const me = await getMe();
   if (me) {

--- a/apps/web/src/app/(routes)/dashboard/choferes/page.tsx
+++ b/apps/web/src/app/(routes)/dashboard/choferes/page.tsx
@@ -2,6 +2,8 @@ import { cookies } from 'next/headers';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 
+export const runtime = 'edge';
+
 interface Driver {
   id: string;
   name: string;

--- a/apps/web/src/app/(routes)/dashboard/principal/page.tsx
+++ b/apps/web/src/app/(routes)/dashboard/principal/page.tsx
@@ -4,6 +4,8 @@ import { DashboardStats } from '@/components/dashboard/dashboard-stats';
 import { RecentAlerts } from '@/components/dashboard/recent-alerts'; // Reemplazamos RecentActivity
 import MapWrapper from '@/components/map/map-wrapper';
 
+export const runtime = 'edge';
+
 // Asumimos estos tipos basados en las respuestas de la API
 type Truck = {
   id: string;

--- a/apps/web/src/app/(routes)/dashboard/ubicaciones/page.tsx
+++ b/apps/web/src/app/(routes)/dashboard/ubicaciones/page.tsx
@@ -1,6 +1,8 @@
 import { cookies } from 'next/headers';
 import { type Route, RoutesTable } from '@/components/dashboard/routes-table';
 
+export const runtime = 'edge';
+
 async function getRoutes(): Promise<Route[]> {
   const cookieStore = await cookies();
   const token = cookieStore.get('better-auth.session_token');

--- a/apps/web/src/app/(routes)/dashboard/vehiculos/page.tsx
+++ b/apps/web/src/app/(routes)/dashboard/vehiculos/page.tsx
@@ -1,6 +1,8 @@
 import { cookies } from 'next/headers';
 import { type Truck, VehiclesTable } from '@/components/dashboard/vehicles-table';
 
+export const runtime = 'edge';
+
 async function getTrucks(): Promise<Truck[]> {
   const cookieStore = await cookies();
   const token = cookieStore.get('better-auth.session_token');

--- a/apps/web/src/app/api/auth/[...all]/route.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.ts
@@ -1,5 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
+export const runtime = 'edge';
+
 const API_BASE_URL = process.env.BETTER_AUTH_URL || 'http://localhost:4000';
 
 async function handler(request: NextRequest) {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,10 +1,11 @@
-import { getSessionCookie } from 'better-auth/cookies';
+import { cookies } from 'next/headers';
 import { type NextRequest, NextResponse } from 'next/server';
 
 import { apiAuthPrefix, authRoutes, DEFAULT_LOGIN_REDIRECT, publicRoutes } from './routes.ts';
 
 export async function middleware(request: NextRequest) {
-  const session = getSessionCookie(request);
+  const cookieStore = await cookies();
+  const session = cookieStore.get('better-auth.session_token');
 
   const isApiAuth = request.nextUrl.pathname.startsWith(apiAuthPrefix);
 


### PR DESCRIPTION
This patch updates several API route and page files to run on the Vercel Edge Runtime and refactors session cookie retrieval in the middleware.

Changes include:

* Edge Runtime enablement

  * Added "export const runtime = 'edge';" to multiple routes and pages:
    * apps/web/src/app/(routes)/(home)/page.tsx
    * apps/web/src/app/(routes)/dashboard/choferes/page.tsx
    * apps/web/src/app/(routes)/dashboard/principal/page.tsx
    * apps/web/src/app/(routes)/dashboard/ubicaciones/page.tsx
    * apps/web/src/app/(routes)/dashboard/vehiculos/page.tsx
    * apps/web/src/app/api/auth/\[...all]/route.ts

* Middleware refactor
  * Updated apps/web/src/middleware.ts to use "cookies" from next/headers for session token retrieval.
  * Removed custom getSessionCookie helper for improved maintainability.